### PR TITLE
Deps update

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14,6 +14,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.66"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "216261ddc8289130e551ddcd5ce8a064710c0d064a4d2895c67151c92b5443f6"
+
+[[package]]
 name = "base16ct"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -134,11 +140,11 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-vault-standard"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
- "cw-utils",
+ "cw-utils 1.0.0",
  "cw20",
  "schemars",
  "serde",
@@ -221,6 +227,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "cw-utils"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b50d0cac456f98b4339b78e890fbe60e4dfe888c87abacc1129fc3fe34bbe20a"
+dependencies = [
+ "anyhow",
+ "cosmwasm-schema",
+ "cosmwasm-std",
+ "cw2",
+ "k256",
+ "schemars",
+ "semver",
+ "serde",
+ "thiserror",
+]
+
+[[package]]
 name = "cw2"
 version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -235,13 +258,13 @@ dependencies = [
 
 [[package]]
 name = "cw20"
-version = "0.16.0"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a45a8794a5dd33b66af34caee52a7beceb690856adcc1682b6e3db88b2cdee62"
+checksum = "a7a4d69a9980e2295077c08fd3f797149658f357167f5898e27c00b9465fcbde"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
- "cw-utils",
+ "cw-utils 0.16.0",
  "schemars",
  "serde",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosmwasm-vault-standard"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 authors = ["Sturdy <sturdy@apollo.farm>"]
 license = "Apache-2.0"
@@ -27,5 +27,5 @@ schemars = "0.8.8"
 serde = { version = "1.0.137", default-features = false, features = ["derive"] }
 # We must unfourtunately use 1.1.5 since there is a breaking change related to `QueryResponses` macro in 1.1.6
 cosmwasm-schema = { version = ">= 1.0.0, <= 1.1.5" }
-cw-utils = { version = "0.16.0", optional = true }
-cw20 = { version = "0.16.0", optional = true }
+cw-utils = { version = "1.0.0", optional = true }
+cw20 = { version = "1.0.0", optional = true }


### PR DESCRIPTION
Main motivation is to update `cw-utils` to 1.0 as Rover depends on the expiration version cw-utils provides.

Also, what do you think about dropping explicitly stating `patch` version? This way, less dep updates on this repo will be needed to maintain compatibility. 